### PR TITLE
fixed compatibility with v0.9.0 of NodeBB

### DIFF
--- a/app/nodebb.js
+++ b/app/nodebb.js
@@ -7,7 +7,7 @@
         emitter      : NodeBB.require('./src/emitter'),
         meta         : NodeBB.require('./src/meta'),
         pluginSockets: NodeBB.require('./src/socket.io/plugins'),
-        postTools    : NodeBB.require('./src/postTools'),
+        postTools    : NodeBB.require('./src/posts/tools'),
         settings     : NodeBB.require('./src/settings'),
         socketIndex  : NodeBB.require('./src/socket.io/index'),
         topics       : NodeBB.require('./src/topics'),

--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "winston": "^1.1.0"
   },
   "nbbpm": {
-    "compatibility": "^0.8.0"
+    "compatibility": "^0.9.0"
   }
 }


### PR DESCRIPTION
Commit nodebb/nodebb@0c6495de72a39bad55950bdefd914ea87bf6901c moved `/src/postTools.js` to `/src/posts/tools.js`. This commit fixes the reference.