### PR TITLE
Sanitize custom field inputs

### DIFF
--- a/client/edit/index.js
+++ b/client/edit/index.js
@@ -1,5 +1,4 @@
 /* globals define, ajaxify, socket, app, config, utils, bootbox */
-
 define('forum/client/plugins/custom-fields-edit', [], function () {
     'use strict';
 
@@ -20,7 +19,7 @@ define('forum/client/plugins/custom-fields-edit', [], function () {
         var data = $form.serializeArray().map(function (item) {
             return {
                 name : item.name.replace(idPrefix, ''),
-                value: item.value
+                value: utils.escapeHTML(item.value)
             }
         });
 


### PR DESCRIPTION
Hi! I know this hasn't been updated in a while, but as far as I can see, people are still forking and using this plugin as recently as a few weeks ago, so I figured I'd toss this up.

I happened to notice what seems to be a pretty serious security flaw. Text inputs for custom fields aren't sanitized, allowing end users to put pretty much whatever they want onto any page where these custom fields are used. As an example, I was able to run arbitrary JavaScript on my forum by setting my "Twitter handle" custom profile field to `"><script>console.log('rekt')</script>`.

A one-line call to the same function used to sanitize the profile inputs in the NodeBB core seems to alleviate this. This should prevent any arbitrary code execution unless the plugin user deliberately drops a custom field inside a script tag.